### PR TITLE
force the use of ac3_fixed

### DIFF
--- a/plugins/video/transcode.py
+++ b/plugins/video/transcode.py
@@ -248,6 +248,8 @@ def select_audiocodec(isQuery, inFile, tsn='', mime=''):
     if ((codec == 'copy' and codectype == 'mpeg2video' and not copy_flag) or
         (copy_flag and copy_flag.lower() == 'false')):
         copyts = ''
+    if codec == 'ac3':
+        codec = 'ac3_fixed'
     return '-acodec ' + codec + copyts
 
 def select_audiofr(inFile, tsn):


### PR DESCRIPTION
on linux mint 14, the default ffmpeg sometimes outputs an overriding hissing if it uses ac3. Forcing ac3_fixed solves the problem for me, but perhaps there's a more suitable workaround.
