### PR TITLE
MP4 metadata improvements

### DIFF
--- a/metadata.py
+++ b/metadata.py
@@ -754,12 +754,12 @@ def dump(output, metadata):
         value = metadata[key]
         if type(value) == list:
             for item in value:
-                output.write('%s: %s\n' % (key, item.encode('utf-8')))
+                output.write('%s : %s\n' % (key, item.encode('utf-8')))
         else:
             if key in HUMAN and value in HUMAN[key]:
-                output.write('%s: %s\n' % (key, HUMAN[key][value]))
+                output.write('%s : %s\n' % (key, HUMAN[key][value]))
             else:
-                output.write('%s: %s\n' % (key, value.encode('utf-8')))
+                output.write('%s : %s\n' % (key, value.encode('utf-8')))
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:

--- a/metadata.py
+++ b/metadata.py
@@ -46,6 +46,11 @@ HUMAN = {'mpaaRating': {1: 'G', 2: 'PG', 3: 'PG-13', 4: 'R', 5: 'X',
          'starRating': {1: '1', 2: '1.5', 3: '2', 4: '2.5', 5: '3',
                         6: '3.5', 7: '4'}}
 
+COLOR_CODES = {'1': ["B & W", 1],
+               '2': ["COLOR AND B & W", 2],
+               '3': ["COLORIZED", 3],
+               '4': ["COLOR", 4]}
+
 BOM = '\xef\xbb\xbf'
 
 GB = 1024 ** 3
@@ -367,7 +372,8 @@ def from_text(full_path):
 
     for rating, ratings in [('tvRating', TV_RATINGS),
                             ('mpaaRating', MPAA_RATINGS),
-                            ('starRating', STAR_RATINGS)]:
+                            ('starRating', STAR_RATINGS),
+                            ('colorCode', COLOR_CODES)]:
         x = metadata.get(rating, '').upper()
         if x in ratings:
             metadata[rating] = ratings[x]

--- a/metadata.py
+++ b/metadata.py
@@ -228,7 +228,16 @@ def from_moov(full_path):
                 for item in items:
                     if item in data:
                         metadata[items[item]] = [x['name'] for x in data[item]]
-
+        elif (key == '----:com.pyTivo.pyTivo:tiVoINFO' and
+              'plistlib' in sys.modules):
+            try:
+                data = plistlib.readPlistFromString(value)
+            except:
+                pass
+            else:
+                for item in data:
+                    metadata[item] = data[item]
+                    
     mp4_cache[full_path] = metadata
     return metadata
 

--- a/metadata.py
+++ b/metadata.py
@@ -44,12 +44,10 @@ HUMAN = {'mpaaRating': {1: 'G', 2: 'PG', 3: 'PG-13', 4: 'R', 5: 'X',
          'tvRating': {1: 'Y7', 2: 'Y', 3: 'G', 4: 'PG', 5: '14',
                       6: 'MA', 7: 'NR'},
          'starRating': {1: '1', 2: '1.5', 3: '2', 4: '2.5', 5: '3',
-                        6: '3.5', 7: '4'}}
-
-COLOR_CODES = {'1': ["B & W", 1],
-               '2': ["COLOR AND B & W", 2],
-               '3': ["COLORIZED", 3],
-               '4': ["COLOR", 4]}
+                        6: '3.5', 7: '4'},
+         'colorCode': {1: 'B & W', 2: 'COLOR AND B & W',
+                        3: 'COLORIZED', 4: 'COLOR'}
+         }
 
 BOM = '\xef\xbb\xbf'
 
@@ -72,6 +70,9 @@ def get_tv(rating):
 
 def get_stars(rating):
     return HUMAN['starRating'].get(rating, '')
+
+def get_color(value):
+    return HUMAN['colorCode'].get(value, 'COLOR')
 
 def human_size(raw):
     raw = float(raw)
@@ -237,7 +238,7 @@ def from_moov(full_path):
             else:
                 for item in data:
                     metadata[item] = data[item]
-                    
+
     mp4_cache[full_path] = metadata
     return metadata
 
@@ -381,8 +382,7 @@ def from_text(full_path):
 
     for rating, ratings in [('tvRating', TV_RATINGS),
                             ('mpaaRating', MPAA_RATINGS),
-                            ('starRating', STAR_RATINGS),
-                            ('colorCode', COLOR_CODES)]:
+                            ('starRating', STAR_RATINGS)]:
         x = metadata.get(rating, '').upper()
         if x in ratings:
             metadata[rating] = ratings[x]

--- a/mutagen/_util.py
+++ b/mutagen/_util.py
@@ -123,6 +123,12 @@ class cdata(object):
 
     from struct import error
 
+    char_le = staticmethod(lambda data: struct.unpack('<b', data)[0])
+    uchar_le = staticmethod(lambda data: struct.unpack('<B', data)[0])
+
+    char_be = staticmethod(lambda data: struct.unpack('>b', data)[0])
+    uchar_be = staticmethod(lambda data: struct.unpack('>B', data)[0])
+
     short_le = staticmethod(lambda data: struct.unpack('<h', data)[0])
     ushort_le = staticmethod(lambda data: struct.unpack('<H', data)[0])
 

--- a/plugins/video/templates/TvBus.tmpl
+++ b/plugins/video/templates/TvBus.tmpl
@@ -25,7 +25,7 @@
             <element>$escape($element)</element>
             #end for
       </vChoreographer>
-      <colorCode value="$video.colorCode[1]">$video.colorCode[0]</colorCode>
+      <colorCode value="$video.colorCode">$get_color($video.colorCode)</colorCode>
       <description>$escape($video.description)</description>
       <vDirector>
             #for $element in $video.vDirector

--- a/plugins/video/video.py
+++ b/plugins/video/video.py
@@ -520,6 +520,7 @@ class BaseVideo(Plugin):
             t.get_tv = metadata.get_tv
             t.get_mpaa = metadata.get_mpaa
             t.get_stars = metadata.get_stars
+            t.get_color = metadata.get_color
             details = str(t)
             self.tvbus_cache[(tsn, file_path)] = details
         return details
@@ -599,7 +600,7 @@ class VideoDetails(DictMixin):
             'displayMajorNumber' : '0',
             'displayMinorNumber' : '0',
             'isEpisode' : 'true',
-            'colorCode' : ('COLOR', '4'),
+            'colorCode' : '4',
             'showType' : ('SERIES', '5')
         }
         if key in defaults:


### PR DESCRIPTION
I've spent quite a while on improving the metadata communication from cTiVo to pyTivo through the MP4 embedded metadata in order to make the roundtrip to TiVo better. I've fixed several items on cTiVo's end, but I think the attached changes would improve pyTiVo's parsing of the metadata. I hope you agree. 

Let me start by acknowledging that I'm neither an expert on pyTiVo nor in Python, so happy to make any changes to this pull request that you think are appropriate. And if I've broken something, my apologies.

The changes are:
1. The MP4 `tven` (TV episode ID) key is not the same as TiVo's `episodeNumber`. `tven` is set by iTunes to `SnEn`, but that's better read from `tvsn` and `tves`; so in TiVo's case, `tven` should be TiVo's programID. Then episodeNumber is constructed from` tvsn/tves` (or `programID` tven's SnEn format) as I think TiVo expects it to be numeric.
2. AFAIK, Tivo's `isEpisode` is true for shows with episodes and movies (as opposed to, for example, news shows), so I set it to false iff the `programID` starts with `SH`, rather than if it's a TV show. (Note that the `stik` atom wasn't even being read by `mutagen/mp4.py`, and it's an integer.)
3. If it's a Movie, then I think it's better to set `movieYear` than `originalAirDate` with the date.
4. In order to read several of these mp4 atoms, I had to add the 8int and 32int parse/render routines into mutagen/mp4.py and the char routines in mutagen/_util.py. These are from updates to that project, but I only copied over the necessary routines. 
5. The last change may be somewhat controversial to you, but it would make the MP4 TiVo metadata complete. The idea is for those TiVo terms that don't map to any MP4 atom, just add a proprietary atom named `----:com.pyTivo.pyTivo:tiVoINFO` (in parallel to `---:com.apple.iTunes:iTunMOVI`) which would simply contain the JSON version of other pyTiVo attributes. This would then remove the need for the user to deal with the little .TXT files entirely, so that the metadata would simply follow along in the MP4 wherever it went. No effect on any programs that don't use it, but it would allow other programs to be more pyTiVo compliant. You'll see it's only a couple lines of code in pyTiVo. I hope you like this idea.

Finally, while I was spending so much time in there, I noticed a couple of very minor things:

First, if the TXT metadata contains `colorCode : 4`, then metadata['colorCode'] is set to 4, rather than ["COLOR",4], which breaks while generating the TVBus template. You'll see in the first commits, I wasn't sure how you'd prefer to fix it, and first did it by trying to maintain the array format, but finally decided that it was better to follow mpaaRating et al, and only keep the integer until the output in TVBus. I note in TVBus.tmpl, that there could be the same problem with showType, but I don't know what the right values are for that.

Secondly, the wiki says that the TXT format is `Key : Value`, but the dump routine wasn't providing the space before the colon. 
