### PR TITLE
Use -bsf:v to avoid issues with unsupported audio

### DIFF
--- a/plugins/video/transcode.py
+++ b/plugins/video/transcode.py
@@ -321,9 +321,9 @@ def select_videocodec(inFile, tsn, mime=''):
         if (mime == 'video/x-tivo-mpeg-ts'):
             org_codec = vInfo.get('vCodec', '')
             if org_codec == 'h264':
-                codec += ['-bsf', 'h264_mp4toannexb']
+                codec += ['-bsf:v', 'h264_mp4toannexb']
             elif org_codec == 'hevc':
-                codec += ['-bsf', 'hevc_mp4toannexb']
+                codec += ['-bsf:v', 'hevc_mp4toannexb']
     else:
         codec += ['mpeg2video', '-pix_fmt', 'yuv420p']  # default
     return codec


### PR DESCRIPTION
Previously, using -bsf would sometimes give an error for an unsupported codec (e.g., ac3 for h264_mp4toannexb, since h264_mp4toannexb is intended only to repack H264 video from an mp4 file). Using of the ":v" suffix isolates the use of the bitstream filter to only the video stream as the code really intended.