### PR TITLE
Fix size estimation for MPEG-4 transport streams.

### DIFF
--- a/plugins/video/transcode.py
+++ b/plugins/video/transcode.py
@@ -536,7 +536,7 @@ def tivo_compatible_video(vInfo, tsn, mime=''):
             break
         # Some requests from the TiVo don't have an associated MIME type. In
         # that case assume an 'h264' codec is going to be compatible.
-        if mime == '' and codec == 'h264':
+        if config.is_ts_capable(tsn) and mime == '' and codec == 'h264':
             logger.debug('Assuming vCodec %s will be compatible', codec)
             break
 
@@ -615,12 +615,12 @@ def tivo_compatible_audio(vInfo, inFile, tsn, mime=''):
 
     return message
 
-def tivo_compatible_container(vInfo, inFile, mime=''):
+def tivo_compatible_container(vInfo, inFile, tsn, mime=''):
     message = (True, '')
     container = vInfo.get('container', '')
     # Some requests from the TiVo don't have an associated MIME type. In
     # that case assume a 'mpegts' container is going to be compatible.
-    if (mime == '' and container == 'mpegts'):
+    if (config.is_ts_capable(tsn) and mime == '' and container == 'mpegts'):
         logger.debug('Assuming container %s will be compatible', container)
         return message
     if ((mime == 'video/x-tivo-mpeg-ts' and container != 'mpegts') or
@@ -650,7 +650,7 @@ def tivo_compatible(inFile, tsn='', mime=''):
             message = amessage
             break
 
-        cmessage = tivo_compatible_container(vInfo, inFile, mime)
+        cmessage = tivo_compatible_container(vInfo, inFile, tsn, mime)
         if not cmessage[0]:
             message = cmessage
 

--- a/plugins/video/transcode.py
+++ b/plugins/video/transcode.py
@@ -534,6 +534,11 @@ def tivo_compatible_video(vInfo, tsn, mime=''):
                 message = (False, 'vCodec %s not compatible' % codec)
 
             break
+        # Some requests from the TiVo don't have an associated MIME type. In
+        # that case assume an 'h264' codec is going to be compatible.
+        if mime == '' and codec == 'h264':
+            logger.debug('Assuming vCodec %s will be compatible', codec)
+            break
 
         if codec not in ('mpeg2video', 'mpeg1video'):
             message = (False, 'vCodec %s not compatible' % codec)
@@ -613,6 +618,11 @@ def tivo_compatible_audio(vInfo, inFile, tsn, mime=''):
 def tivo_compatible_container(vInfo, inFile, mime=''):
     message = (True, '')
     container = vInfo.get('container', '')
+    # Some requests from the TiVo don't have an associated MIME type. In
+    # that case assume a 'mpegts' container is going to be compatible.
+    if (mime == '' and container == 'mpegts'):
+        logger.debug('Assuming container %s will be compatible', container)
+        return message
     if ((mime == 'video/x-tivo-mpeg-ts' and container != 'mpegts') or
         (mime in ['video/x-tivo-mpeg', 'video/mpeg', ''] and
          (container != 'mpeg' or vInfo['vCodec'] == 'mpeg1video'))):


### PR DESCRIPTION
This can reduce the number of programs that TiVo deletes upon their transfer.

TiVo requests the expected transfer size *before* it tries to actually transfer
a file, and it does not send a desired MIME type along with that request.  When
that MIME type is missing and the vCodec is "h264", tivo_compatible_video()
returned false -- which resulted in __est_size() estimating the size as if it
will transcode the video.  And, without also having this fix in
tivo_compatible_container(), that estimated size can be 2-3 times too big
because the bitrate may not reflect what's in the actual file.